### PR TITLE
🐛 Fix register route validation error

### DIFF
--- a/apps/web/src/app/api/auth/register/route.ts
+++ b/apps/web/src/app/api/auth/register/route.ts
@@ -26,7 +26,7 @@ export async function POST(request: NextRequest) {
     // Hash password
     const hashedPassword = await hashPassword(validatedData.password);
     
-    // Create user
+    // Create user with default values for required fields
     const user = await prisma.user.create({
       data: {
         email: validatedData.email,
@@ -34,9 +34,10 @@ export async function POST(request: NextRequest) {
         firstName: validatedData.firstName,
         lastName: validatedData.lastName,
         companyName: validatedData.companyName,
-        language: validatedData.language || 'en',
-        dataRegion: validatedData.dataRegion || 'EU',
-        timezone: validatedData.timezone || 'UTC',
+        // Use default values for fields not in the schema
+        language: 'en',
+        dataRegion: 'EU',
+        timezone: 'UTC',
       },
       select: {
         id: true,


### PR DESCRIPTION
## 🐛 Fix Register Route Validation Error

### Problem
The deployment was failing with another TypeScript error:
```
Type error: Property 'language' does not exist on type '{ email: string; firstName: string; ... }'
```

The `registerSchema` validation schema doesn't include `language`, `dataRegion`, and `timezone` fields, but the register route was trying to access them from `validatedData`.

### Solution
- Use hardcoded default values for these fields instead of trying to access them from the validated data
- `language: 'en'` (default)
- `dataRegion: 'EU'` (default)
- `timezone: 'UTC'` (default)

### Files Changed
- `apps/web/src/app/api/auth/register/route.ts` - Fixed to use default values for fields not in the validation schema

### Verification
✅ The TypeScript compilation error is fixed
✅ Default values are properly set for required database fields
✅ Registration flow will work correctly

This is an urgent fix to complete the deployment restoration.