### PR TITLE
Fix: Remove ReactQueryDevtools import blocking build

### DIFF
--- a/BUILD_FIX_LOG.md
+++ b/BUILD_FIX_LOG.md
@@ -28,6 +28,11 @@
    - Replaced incompatible regex with ES5-compatible solution
    - Updated TypeScript target to ES2020 for modern features
 
+6. **React Query DevTools import** ✅
+   - Removed optional ReactQueryDevtools import
+   - Package was not installed and is only needed for development
+   - Commented out the import to prevent build errors
+
 ## 🛠️ Configuration Required in Vercel
 
 ### Environment Variables to Set:
@@ -78,6 +83,7 @@ STRIPE_WEBHOOK_SECRET=
 - ✅ Added production environment template
 - ✅ Fixed regex compatibility issues
 - ✅ Updated TypeScript configuration
+- ✅ Removed optional dev dependencies from production build
 - ✅ Ready for Vercel deployment
 
 ## Commits Applied:
@@ -88,8 +94,9 @@ STRIPE_WEBHOOK_SECRET=
 5. Fix TypeScript type indexing error in Stripe webhook
 6. Fix regex flag error - replace /s flag with compatible solution
 7. Update TypeScript config to target ES2020 for modern features support
+8. Remove ReactQueryDevtools import - not installed and optional for dev
 
 ---
 
 **Build Status:** Ready for deployment 🚀
-**Last Update:** September 21, 2025 12:45 UTC
+**Last Update:** September 21, 2025 13:03 UTC

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+// ReactQueryDevtools is optional and only for development
+// import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { Toaster } from 'react-hot-toast';
 import { useState } from 'react';
 import { IntlProvider } from '@/components/providers/intl-provider';
@@ -52,7 +53,8 @@ export function Providers({ children }: { children: React.ReactNode }) {
           </AuthProvider>
         </ThemeProvider>
       </IntlProvider>
-      <ReactQueryDevtools initialIsOpen={false} />
+      {/* ReactQueryDevtools is optional and only needed in development */}
+      {/* <ReactQueryDevtools initialIsOpen={false} /> */}
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
## 🚀 Fix Build Error - React Query DevTools Import

### 🐛 Problem Fixed

This PR addresses the build error encountered during Vercel deployment:

**Error:** 
```
Type error: Cannot find module '@tanstack/react-query-devtools' or its corresponding type declarations.
```

### ✅ Changes Made

1. **Removed ReactQueryDevtools Import**
   - Commented out the import of `@tanstack/react-query-devtools` in `apps/web/src/app/providers.tsx`
   - This package is optional and only needed for development
   - It was not installed and was causing build failures in production
   - The component usage has also been commented out

### 📝 Files Changed

- `apps/web/src/app/providers.tsx` - Removed/commented ReactQueryDevtools import and usage
- `BUILD_FIX_LOG.md` - Updated documentation with this fix

### 🧪 Testing

- [x] Code compiles without import errors
- [x] React Query still functions properly without devtools
- [x] Ready for Vercel deployment

### 📦 Deployment

After merging this PR, the Vercel deployment should succeed. The ReactQueryDevtools can be re-added later if needed for development by:

1. Installing the package: `npm install @tanstack/react-query-devtools`
2. Conditionally loading it only in development environment

### 🎯 Impact

This fix removes an unnecessary development dependency that was blocking production builds.

---

**Build Status:** ✅ Ready for deployment
**Priority:** 🔴 High - Blocking deployment