### PR TITLE
🐛 Fix: Add missing @heroicons/react dependency

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "@prisma/client": "^5.22.0",
     "prisma": "^5.22.0",
     "@tanstack/react-query": "^5.65.0",
+    "@heroicons/react": "^2.2.0",
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-dropdown-menu": "^2.1.4",
     "@radix-ui/react-label": "^2.1.2",


### PR DESCRIPTION
## 🐛 Fix Missing Dependency - @heroicons/react

### Problem
The Vercel build was failing with:
```
Type error: Cannot find module '@heroicons/react/24/outline' or its corresponding type declarations.
```

### Root Cause
The `@heroicons/react` package was not included in the dependencies of `apps/web/package.json`, but it's being imported in `overview.tsx` and other dashboard components.

### Solution
Added `@heroicons/react` version 2.2.0 to the dependencies.

### Impact
This was preventing the TypeScript compilation and blocking the Vercel deployment.

### Testing
- [x] Dependency added to package.json
- [x] Version compatible with existing React version
- [ ] Build should now succeed on Vercel

**Priority:** 🔴 Critical - Blocking deployment
**Type:** Bug Fix / Missing Dependency