### PR TITLE
🐛 Fix: Replace non-existent TrendingUpIcon with ArrowTrendingUpIcon

### DIFF
--- a/apps/web/src/components/dashboard/overview.tsx
+++ b/apps/web/src/components/dashboard/overview.tsx
@@ -6,7 +6,7 @@ import {
   ChartBarIcon, 
   UserGroupIcon, 
   EnvelopeIcon, 
-  TrendingUpIcon,
+  ArrowTrendingUpIcon,
   PlusIcon,
   EyeIcon
 } from '@heroicons/react/24/outline';
@@ -109,7 +109,7 @@ export function DashboardOverview() {
       title: t('dashboard.stats.qualifiedProspects'),
       value: stats?.qualifiedProspects || 0,
       change: ((stats?.qualifiedProspects || 0) / (stats?.totalProspects || 1)) * 100,
-      icon: TrendingUpIcon,
+      icon: ArrowTrendingUpIcon,
       color: 'text-green-600',
       bgColor: 'bg-green-50',
       isPercentage: true,


### PR DESCRIPTION
## 🐛 Fix: Correction de l'erreur de build Vercel

### ❌ Problème
Le build Vercel échouait avec l'erreur :
```
Type error: Module '"@heroicons/react/24/outline"' has no exported member 'TrendingUpIcon'.
```

### ✅ Solution
- Remplacé `TrendingUpIcon` par `ArrowTrendingUpIcon` dans le composant dashboard
- Cette icône a été renommée dans Heroicons v2

### 📝 Changements
- **apps/web/src/components/dashboard/overview.tsx** : Utilisation de `ArrowTrendingUpIcon` au lieu de `TrendingUpIcon`

### 🧪 Tests
- [ ] Build local réussi
- [ ] Build Vercel réussi
- [ ] Composant dashboard fonctionne correctement

### 📊 Impact
Ce fix permet au build de passer et l'application peut être déployée sur Vercel.

---
**Type de changement** : 🐛 Bug fix
**Breaking change** : Non