### PR TITLE
🔥 HOTFIX: Retirer l'extension .tsx pour corriger le build Vercel

### DIFF
--- a/apps/web/src/hooks/use-i18n.ts
+++ b/apps/web/src/hooks/use-i18n.ts
@@ -1,5 +1,4 @@
-// This file has been removed.
-// Please import directly from './use-i18n.tsx' instead.
-// This is a placeholder to prevent breaking existing imports.
+// This file re-exports from use-i18n.tsx
+// It acts as a bridge to prevent breaking existing imports
 
-export { useI18n, I18nProvider } from './use-i18n.tsx';
+export { useI18n, I18nProvider } from './use-i18n';


### PR DESCRIPTION
## 🔥 Hotfix: Correction urgente de l'erreur de build Vercel

### 🐛 Problème identifié
Le build Vercel échoue avec l'erreur :
```
Type error: An import path can only end with a '.tsx' extension when 'allowImportingTsExtensions' is enabled.
```

Erreur située dans : `apps/web/src/hooks/use-i18n.ts` ligne 5

### ✅ Solution appliquée
Suppression de l'extension `.tsx` dans l'instruction d'import :
- **Avant** : `export { useI18n, I18nProvider } from './use-i18n.tsx';`
- **Après** : `export { useI18n, I18nProvider } from './use-i18n';`

### 🚀 Impact
- Le build Vercel devrait maintenant réussir
- TypeScript résoudra correctement les imports sans nécessiter d'extension
- Compatible avec la configuration TypeScript standard de Next.js

### 📝 Note
C'est un correctif simple mais critique qui débloque le déploiement. TypeScript ne permet pas les extensions de fichiers dans les imports sauf si `allowImportingTsExtensions` est activé, ce qui n'est pas le cas dans notre configuration.

**Merci de merger rapidement cette PR pour débloquer le déploiement ! 🙏**