### PR TITLE
🐛 Fix: Remove .tsx extension from import to resolve Vercel build error

### DIFF
--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -1,3 +1,3 @@
 // Export all hooks from this directory
 export { useAuth } from './use-auth';
-export { useI18n, I18nProvider } from './use-i18n.tsx';
+export { useI18n, I18nProvider } from './use-i18n';


### PR DESCRIPTION
## 🐛 Fix Description

This PR fixes the Vercel build error that was preventing successful deployment.

## 🔴 Error Details

The build was failing with:
```
Type error: An import path can only end with a '.tsx' extension when 'allowImportingTsExtensions' is enabled.
```

## ✅ Solution

- Removed the `.tsx` extension from the import statement in `apps/web/src/hooks/index.ts`
- Changed `from './use-i18n.tsx'` to `from './use-i18n'`

## 📋 Changes Made

- **File Modified**: `apps/web/src/hooks/index.ts`
  - Line 3: Fixed import statement to use TypeScript's standard module resolution without explicit file extension

## 🧪 Testing

- The TypeScript compiler now correctly resolves the module without requiring explicit file extensions
- This follows TypeScript best practices for module imports
- Build should now complete successfully on Vercel

## 🚀 Impact

This fix will allow the Vercel deployment to proceed without errors, unblocking the production deployment pipeline.