### PR TITLE
🐛 Fix: Move TypeScript types to dependencies for production build

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,6 +29,8 @@
     "@radix-ui/react-toast": "^1.2.4",
     "@hookform/resolvers": "^3.9.1",
     "bcryptjs": "^2.4.3",
+    "@types/bcryptjs": "^2.4.6",
+    "@types/jsonwebtoken": "^9.0.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
@@ -50,8 +52,6 @@
     "@types/react-dom": "^18"
   },
   "devDependencies": {
-    "@types/bcryptjs": "^2.4.6",
-    "@types/jsonwebtoken": "^9.0.7",
     "eslint": "^8",
     "eslint-config-next": "14.2.32"
   }


### PR DESCRIPTION
## 🐛 Fix Description

This PR fixes the TypeScript build error on Vercel production builds for missing type definitions.

## 🔴 Error Details

The build was failing with:
```
Type error: Could not find a declaration file for module 'jsonwebtoken'. 
'/vercel/path0/node_modules/jsonwebtoken/index.js' implicitly has an 'any' type.
```

## ✅ Root Cause

In production builds, TypeScript type definitions need to be in `dependencies` rather than `devDependencies`. Vercel's production build only installs `dependencies`, not `devDependencies`.

## ✅ Solution

Moved the following packages from `devDependencies` to `dependencies`:
- `@types/jsonwebtoken`
- `@types/bcryptjs`

These type definitions are required during the TypeScript compilation step of the production build.

## 📋 Changes Made

- **File Modified**: `apps/web/package.json`
  - Moved `@types/jsonwebtoken` from devDependencies → dependencies
  - Moved `@types/bcryptjs` from devDependencies → dependencies

## 🧪 Impact

- TypeScript will now find the type definitions during production builds
- No functional changes, only build configuration
- This is a common issue with Next.js production builds on Vercel

## 📚 Reference

This is a known pattern with Next.js apps on Vercel where type definitions need to be in `dependencies` for production builds, even though they're technically only used during compilation.