### PR TITLE
🐛 Fix: Add missing jose dependency for JWT authentication

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,6 +34,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
+    "jose": "^5.9.6",
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.475.0",
     "react-hook-form": "^7.54.2",


### PR DESCRIPTION
## 🐛 Fix: Ajout de la dépendance manquante `jose`

### 📋 Description
Cette PR corrige l'erreur de build sur Vercel qui empêchait le déploiement de l'application.

### 🔍 Problème
Le log de Vercel montrait l'erreur suivante :
```
Type error: Cannot find module 'jose' or its corresponding type declarations.
```

Le fichier `/src/lib/auth/jwt.ts` importait le module `jose` pour la gestion des JWT, mais cette dépendance n'était pas présente dans le `package.json`.

### ✅ Solution
- Ajout de la dépendance `jose` (version ^5.9.6) dans le `package.json` de l'app web
- Cette bibliothèque est utilisée pour la génération et vérification sécurisée des JWT

### 🚀 Impact
- Le build devrait maintenant passer avec succès sur Vercel
- L'authentification JWT fonctionnera correctement en production

### 📝 Notes
- `jose` est une implémentation moderne et sécurisée des JWT recommandée pour Next.js
- Elle coexiste avec `jsonwebtoken` qui peut être utilisé côté serveur si nécessaire

### ✔️ Tests
- [ ] Build local réussi
- [ ] Déploiement Vercel réussi
- [ ] Authentification fonctionnelle

---
**Type de changement:** Fix
**Breaking change:** Non