### PR TITLE
🐛 Fix: TypeScript iteration error on Map.entries()

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "ES2015",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
@@ -12,6 +13,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "downlevelIteration": true,
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## 🐛 Fix: Résolution de l'erreur TypeScript pour l'itération sur Map

### 📋 Description
Cette PR corrige l'erreur de compilation TypeScript qui empêche le build sur Vercel.

### 🔍 Problème
Le log de Vercel montrait l'erreur suivante dans `/src/lib/auth/rate-limit.ts`:
```
Type error: Type 'MapIterator<[string, { count: number; resetAt: number; }]>' can only be iterated through when using the '--downlevelIteration' flag or with a '--target' of 'es2015' or higher.
```

Le problème se produisait lors de l'itération sur `Map.entries()` dans le code de rate limiting :
```typescript
for (const [key, value] of attempts.entries()) {
  // ...
}
```

### ✅ Solution
Modification du `tsconfig.json` avec :
- **Ajout de `"target": "ES2015"`** : Définit la version ECMAScript cible pour supporter nativement l'itération sur Map
- **Ajout de `"downlevelIteration": true`** : Active la transformation pour une compatibilité complète avec les itérateurs

### 🔧 Détails techniques
Ces modifications permettent :
- L'utilisation native de `for...of` sur les itérateurs Map/Set
- La compatibilité avec les environnements qui nécessitent ES5
- Un support complet des fonctionnalités ES2015+ dans le code compilé

### 🚀 Impact
- Le build TypeScript passera maintenant avec succès
- Le système de rate limiting fonctionnera correctement
- Aucun changement de comportement du code

### ✔️ Tests
- [ ] Build local réussi avec `npm run build`
- [ ] Déploiement Vercel réussi
- [ ] Rate limiting fonctionnel

---
**Type de changement:** Fix
**Breaking change:** Non
**Issue associée:** Erreur de build Vercel