### PR TITLE
🐛 Fix: Correct TypeScript error in RBAC canPerformAction function

### DIFF
--- a/apps/web/src/lib/auth/rbac.ts
+++ b/apps/web/src/lib/auth/rbac.ts
@@ -106,8 +106,9 @@ export function canPerformAction(
     case 'icp':
     case 'sequence':
     case 'campaign':
-      // All roles except admin can manage business resources
-      return role !== 'ADMIN' || action === 'read';
+      // All non-admin roles can manage business resources
+      // Since we already checked for ADMIN above, all roles here can manage these resources
+      return true;
       
     default:
       return false;


### PR DESCRIPTION
## 🐛 Fix TypeScript Error in RBAC

### Problem
The Vercel build was failing with a TypeScript error in `apps/web/src/lib/auth/rbac.ts` at line 110:
```
Type error: This comparison appears to be unintentional because the types '"CLIENT" | "TEAM_MEMBER" | "TEAM_OWNER"' and '"ADMIN"' have no overlap.
```

### Root Cause
In the `canPerformAction` function, we check if `role === 'ADMIN'` and return `true` early (line 89). This means when we reach the switch statement, TypeScript knows that `role` can never be 'ADMIN'. The comparison `role !== 'ADMIN'` was therefore redundant and caused a type error.

### Solution
- Removed the redundant `role !== 'ADMIN'` check 
- Updated the logic to simply return `true` for business resources (prospect, icp, sequence, campaign)
- Clarified the comment to explain that all non-admin roles can manage these resources

### Changes
- Fixed `apps/web/src/lib/auth/rbac.ts` line 110
- Updated comment for clarity

### Testing
✅ TypeScript compilation should now pass
✅ RBAC logic remains unchanged (all non-admin roles can manage business resources)

This fix will resolve the Vercel deployment issue.