### PR TITLE
🐛 Fix: Correct async function return types in JWT module

### DIFF
--- a/apps/web/src/lib/jwt.ts
+++ b/apps/web/src/lib/jwt.ts
@@ -20,7 +20,7 @@ interface TokenPayload {
   plan?: string
 }
 
-export async function generateAccessToken(user: any): string {
+export async function generateAccessToken(user: any): Promise<string> {
   const token = await new SignJWT({
     userId: user.id,
     email: user.email,
@@ -37,7 +37,7 @@ export async function generateAccessToken(user: any): string {
   return token
 }
 
-export async function generateRefreshToken(userId: string): string {
+export async function generateRefreshToken(userId: string): Promise<string> {
   const token = await new SignJWT({ userId, type: 'refresh' })
     .setProtectedHeader({ alg: 'HS256' })
     .setExpirationTime(JWT_REFRESH_EXPIRES_IN)


### PR DESCRIPTION
## 🐛 Fix TypeScript Error in JWT Module

### Problem
The Vercel build was failing with a TypeScript error in `apps/web/src/lib/jwt.ts` at line 23:
```
Type error: The return type of an async function or method must be the global Promise<T> type. Did you mean to write 'Promise<string>'?
```

### Root Cause
Async functions in TypeScript must have a return type of `Promise<T>` not just `T`. The functions `generateAccessToken` and `generateRefreshToken` were incorrectly typed with return type `string` instead of `Promise<string>`.

### Solution
- Changed return type from `string` to `Promise<string>` for `generateAccessToken` function
- Changed return type from `string` to `Promise<string>` for `generateRefreshToken` function
- Both functions now correctly reflect their async nature in their type signatures

### Changes
- Fixed `apps/web/src/lib/jwt.ts` line 23: `generateAccessToken` return type
- Fixed `apps/web/src/lib/jwt.ts` line 39: `generateRefreshToken` return type

### Testing
✅ TypeScript compilation should now pass
✅ JWT generation logic remains unchanged
✅ All async functions now have proper Promise return types

This fix will resolve the second Vercel deployment issue.