### PR TITLE
fix: add missing lru-cache dependency for Vercel build

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,6 +37,7 @@
     "jose": "^5.9.6",
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.475.0",
+    "lru-cache": "^10.2.0",
     "react-hook-form": "^7.54.2",
     "react-hot-toast": "^2.5.0",
     "sonner": "^1.7.2",


### PR DESCRIPTION
## 🐛 Fix: Add missing lru-cache dependency

### Problem
The Vercel build was failing with the following error:
```
Type error: Cannot find module 'lru-cache' or its corresponding type declarations.
```

### Solution
Added the missing `lru-cache` package (v10.2.0) to the `apps/web/package.json` dependencies.

### Changes
- ✅ Added `lru-cache: ^10.2.0` to dependencies in `apps/web/package.json`

### Testing
The package is used in `apps/web/src/lib/rate-limiter.ts` for implementing rate limiting functionality. This PR will fix the build error and allow successful deployment on Vercel.

### Build Log Reference
The error was detected in the Vercel build at timestamp 17:15:17.096

---
**Deployment ready** ✅