### PR TITLE
fix: handle null JWT payload and use correct field names in auth routes

### DIFF
--- a/apps/web/src/app/api/auth/logout/route.ts
+++ b/apps/web/src/app/api/auth/logout/route.ts
@@ -10,10 +10,14 @@ export async function POST(request: NextRequest) {
       try {
         const payload = verifyAccessToken(accessToken);
         
-        // Delete all sessions for this user
-        await prisma.session.deleteMany({
-          where: { userId: payload.userId },
-        });
+        // Check if payload is not null before using it
+        if (payload) {
+          // Delete all sessions for this user
+          // Using 'id' instead of 'userId' to match the JWT payload structure
+          await prisma.session.deleteMany({
+            where: { userId: payload.id },
+          });
+        }
         
       } catch (error) {
         // Token might be expired, but we still want to clear cookies

--- a/apps/web/src/app/api/auth/refresh/route.ts
+++ b/apps/web/src/app/api/auth/refresh/route.ts
@@ -16,13 +16,22 @@ export async function POST(request: NextRequest) {
     // Verify refresh token
     const payload = verifyRefreshToken(refreshToken);
     
+    // Check if payload is not null
+    if (!payload) {
+      return NextResponse.json(
+        { error: 'Invalid refresh token' },
+        { status: 401 }
+      );
+    }
+    
     // Find session with refresh token
     const session = await prisma.session.findUnique({
       where: { refreshToken },
       include: { user: true },
     });
     
-    if (!session || session.userId !== payload.userId) {
+    // Using 'id' instead of 'userId' to match the JWT payload structure
+    if (!session || session.userId !== payload.id) {
       return NextResponse.json(
         { error: 'Invalid refresh token' },
         { status: 401 }


### PR DESCRIPTION
## 🐛 Fix: Handle null JWT payload and correct field references in auth routes

### Problem
The Vercel build was failing with the following TypeScript error in `logout/route.ts`:
```
Type error: 'payload' is possibly 'null'.
```

Additionally, there were field reference errors:
- Both logout and refresh routes were using `payload.userId` instead of `payload.id`
- No null checking for the JWT payload after verification

### Root Cause
After our previous fix where we made `verifyAccessToken` and `verifyRefreshToken` return `null` on error (instead of throwing), the consuming code wasn't updated to handle the possibility of null values.

### Solution
✅ **Fixed in logout/route.ts**:
- Added null check for `payload` before using it
- Changed `payload.userId` to `payload.id` to match the JWT structure

✅ **Fixed in refresh/route.ts**:
- Added null check for `payload` after verification
- Changed `payload.userId` to `payload.id` to match the JWT structure

### Changes Made
1. **apps/web/src/app/api/auth/logout/route.ts**
   - Added `if (payload)` check before accessing payload properties
   - Changed from `payload.userId` to `payload.id`

2. **apps/web/src/app/api/auth/refresh/route.ts**
   - Added early return if `payload` is null
   - Changed from `payload.userId` to `payload.id` in session validation

### Testing Notes
- JWT verification now safely handles null returns
- Field references are consistent with the JWT payload structure
- TypeScript compilation should succeed

---
**Build Ready** ✅