### PR TITLE
Fix: Resolve TypeScript export conflict for ICPCriteria type

### DIFF
--- a/packages/core/schemas.ts
+++ b/packages/core/schemas.ts
@@ -78,9 +78,9 @@ export const EmailSequenceCreateSchema = z.object({
   steps: z.array(EmailSequenceStepSchema).min(1, 'At least one step is required').max(10)
 });
 
-// Type exports
+// Type exports with renamed ICPCriteria to avoid conflict with types.ts
 export type UserRegistration = z.infer<typeof UserRegistrationSchema>;
-export type ICPCriteria = z.infer<typeof ICPCriteriaSchema>;
+export type ICPCriteriaInput = z.infer<typeof ICPCriteriaSchema>;  // Renamed from ICPCriteria to avoid conflict
 export type ICPCreate = z.infer<typeof ICPCreateSchema>;
 export type ProspectCreate = z.infer<typeof ProspectCreateSchema>;
 export type EmailSequenceCreate = z.infer<typeof EmailSequenceCreateSchema>;


### PR DESCRIPTION
## 🔧 Fix TypeScript Export Conflict

This PR fixes a critical TypeScript compilation error that was preventing the Vercel build from completing.

### 🐛 Problem

The build was failing with the error:
```
Type error: Module './types' has already exported a member named 'ICPCriteria'. Consider explicitly re-exporting to resolve the ambiguity.
```

This occurred in `/packages/core/index.ts` because both `types.ts` and `schemas.ts` were exporting a member named `ICPCriteria`.

### ✅ Solution

Renamed the conflicting type in `schemas.ts`:
- **Before**: `export type ICPCriteria = z.infer<typeof ICPCriteriaSchema>;`
- **After**: `export type ICPCriteriaInput = z.infer<typeof ICPCriteriaSchema>;`

### 📋 Changes

1. **packages/core/schemas.ts**:
   - Renamed the inferred type from `ICPCriteria` to `ICPCriteriaInput`
   - This avoids conflict with the `ICPCriteria` interface in `types.ts`
   - The naming is more semantic: `ICPCriteriaInput` for validation, `ICPCriteria` for the interface

### 🎯 Impact

- Vercel build will now pass the TypeScript compilation step
- No breaking changes for existing code (unless they were using the `ICPCriteria` type from schemas)
- Clear separation between validation types (schemas) and interface types

### 📝 Notes

- The `ICPCriteria` interface in `types.ts` remains unchanged
- The Zod schema `ICPCriteriaSchema` remains unchanged
- Only the inferred type name was changed to avoid the export conflict

### 🚀 Deployment

After merging this PR, the Vercel deployment should proceed successfully.