### PR TITLE
Fix: Correct password field name to match Prisma schema

### DIFF
--- a/apps/web/src/app/api/auth/login/route.ts
+++ b/apps/web/src/app/api/auth/login/route.ts
@@ -27,8 +27,8 @@ export async function POST(request: Request) {
       )
     }
 
-    // Verify password
-    const isValidPassword = await verifyPassword(password, user.password)
+    // Verify password - using hashedPassword field from database
+    const isValidPassword = await verifyPassword(password, user.hashedPassword)
     if (!isValidPassword) {
       return NextResponse.json(
         { success: false, message: 'Invalid email or password' },

--- a/apps/web/src/app/api/auth/register/route.ts
+++ b/apps/web/src/app/api/auth/register/route.ts
@@ -55,13 +55,13 @@ export async function POST(request: Request) {
     }
 
     // Hash password
-    const hashedPassword = await hashPassword(data.password)
+    const hashedPasswordValue = await hashPassword(data.password)
 
     // Create new user with subscription
     const newUser = await prisma.user.create({
       data: {
         email: data.email.toLowerCase(),
-        password: hashedPassword,
+        hashedPassword: hashedPasswordValue, // Using correct field name from schema
         firstName: data.firstName,
         lastName: data.lastName,
         companyName: data.companyName,


### PR DESCRIPTION
# 🔧 Fix Password Field Name in Authentication Routes

This PR fixes the critical build error related to incorrect password field naming in the authentication routes.

## 🐛 Problem

The Vercel build was failing with the error:
```
Property 'password' does not exist on type '{ id: string; ... hashedPassword: string; ...}'
```

The Prisma schema defines the password field as `hashedPassword`, but the authentication routes were trying to access it as `password`.

## ✅ Solution

### Changes Made:

1. **`login/route.ts`**
   - Changed `user.password` to `user.hashedPassword` when verifying password
   - Added comment to clarify the field name from database

2. **`register/route.ts`**
   - Changed `password: hashedPassword` to `hashedPassword: hashedPasswordValue`
   - Renamed variable to `hashedPasswordValue` to avoid confusion
   - Added comment to clarify the correct field name

## 🧪 Testing

These changes ensure:
- ✅ Correct field names match the Prisma schema
- ✅ Build errors are resolved
- ✅ Authentication flow works correctly with the database

## 📝 Notes

- The field is named `hashedPassword` in the database to clearly indicate it stores the hashed value, not plain text
- This is a security best practice to prevent accidental exposure of plain passwords

## ✅ Checklist

- [x] Fixed field name mismatches
- [x] Added clarifying comments
- [x] Build should now succeed
- [x] Authentication flow preserved

---

**Ready for review and merge to fix the build** 🚀