### PR TITLE
Fix: Remove unused I18nProvider export causing build error

### DIFF
--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -1,3 +1,4 @@
 // Export all hooks from this directory
 export { useAuth } from './use-auth';
-export { useI18n, I18nProvider } from './use-i18n';
+export { useI18n } from './use-i18n';
+export { I18nProvider } from './use-i18n';

--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -1,4 +1,3 @@
 // Export all hooks from this directory
 export { useAuth } from './use-auth';
 export { useI18n } from './use-i18n';
-export { I18nProvider } from './use-i18n';


### PR DESCRIPTION
## 🐛 Fix Build Error

### Problem
The Vercel build was failing with the following error:
```
Type error: Module '"./use-i18n"' has no exported member 'I18nProvider'.
```

### Root Cause
The `hooks/index.ts` file was trying to export `I18nProvider` from `use-i18n`, but this export was not being used anywhere in the codebase. The actual internationalization is handled by `IntlProvider` from `@/components/providers/intl-provider.tsx`.

### Solution
- Removed the unused `I18nProvider` export from `hooks/index.ts`
- Kept only the necessary exports: `useAuth` and `useI18n`

### Testing
This fix should resolve the TypeScript compilation error during the Vercel build process.

### Note
There are two parallel i18n systems in the codebase:
1. `useI18n` hook with `I18nProvider`
2. `useIntl` hook with `IntlProvider`

Consider consolidating to a single i18n solution in a future refactor.