### PR TITLE
Fix: Resolve JWT payload type conflict with jose library

### DIFF
--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -11,7 +11,8 @@ const JWT_REFRESH_SECRET = new TextEncoder().encode(
   process.env.JWT_REFRESH_SECRET || process.env.JWT_SECRET || 'your-refresh-secret-key-change-in-production'
 )
 
-export interface JWTPayload {
+// Rename our custom interface to avoid conflict with jose's JWTPayload
+export interface AuthPayload {
   id: string  // Changed from userId to id to match the token generation
   userId: string
   email: string
@@ -61,14 +62,40 @@ export async function createRefreshToken(user: User) {
     .sign(JWT_REFRESH_SECRET)
 }
 
-export async function verifyAccessToken(token: string): Promise<JWTPayload> {
+export async function verifyAccessToken(token: string): Promise<AuthPayload> {
   const { payload } = await jwtVerify(token, JWT_SECRET)
-  return payload as JWTPayload
+  
+  // Validate that the payload has the required fields
+  if (!payload.id || !payload.userId || !payload.email || !payload.role) {
+    throw new Error('Invalid token payload')
+  }
+  
+  return {
+    id: payload.id as string,
+    userId: payload.userId as string,
+    email: payload.email as string,
+    role: payload.role as string,
+    iat: payload.iat,
+    exp: payload.exp
+  }
 }
 
-export async function verifyRefreshToken(token: string): Promise<JWTPayload> {
+export async function verifyRefreshToken(token: string): Promise<AuthPayload> {
   const { payload } = await jwtVerify(token, JWT_REFRESH_SECRET)
-  return payload as JWTPayload
+  
+  // Validate that the payload has the required fields
+  if (!payload.id || !payload.userId || !payload.email || !payload.role) {
+    throw new Error('Invalid token payload')
+  }
+  
+  return {
+    id: payload.id as string,
+    userId: payload.userId as string,
+    email: payload.email as string,
+    role: payload.role as string,
+    iat: payload.iat,
+    exp: payload.exp
+  }
 }
 
 export async function hashPassword(password: string): Promise<string> {


### PR DESCRIPTION
## 🐛 Fix JWT Type Conflict

### Problem
The Vercel build was failing with the following TypeScript error:
```
Type error: Conversion of type 'JWTPayload' to type 'JWTPayload' may be a mistake...
Type 'JWTPayload' is missing the following properties from type 'JWTPayload': id, userId, email, role
```

### Root Cause
There was a type conflict between:
1. `jose` library's built-in `JWTPayload` type
2. Our custom `JWTPayload` interface with additional fields

The type casting from jose's `JWTPayload` to our custom type was failing because they don't have sufficient overlap.

### Solution
1. **Renamed custom interface**: Changed `JWTPayload` to `AuthPayload` to avoid naming conflicts
2. **Added validation**: Added explicit field validation before constructing the return object
3. **Improved type safety**: Properly cast individual fields with type assertions after validation

### Changes
- `apps/web/src/lib/auth.ts`:
  - Renamed `JWTPayload` interface to `AuthPayload`
  - Updated `verifyAccessToken()` and `verifyRefreshToken()` to return `AuthPayload`
  - Added validation to ensure payload contains required fields
  - Explicitly construct return object with proper types

### Testing
This should resolve the TypeScript compilation error during the Vercel build process.

### Impact
- No breaking changes for the application logic
- Improved type safety and error handling
- Clear separation between library types and custom types